### PR TITLE
Update _proxy.py: fix add_ip_to_port

### DIFF
--- a/openstack/network/v2/_proxy.py
+++ b/openstack/network/v2/_proxy.py
@@ -1536,7 +1536,7 @@ class Proxy(proxy2.BaseProxy):
         return self._update(_port.Port, port, **attrs)
 
     def add_ip_to_port(self, port, ip):
-        ip['port_id'] = port.id
+        ip.port_id = port.id
         return ip.update(self)
 
     def remove_ip_from_port(self, ip):


### PR DESCRIPTION
Fix error in add_ip_to_port
TypeError: 'FloatingIP' object does not support item assignment

```
def add_ip_to_port(self, port, ip):
>       ip['port_id'] = port.id
E       TypeError: 'FloatingIP' object does not support item assignment
```